### PR TITLE
42 memory store unit test

### DIFF
--- a/app/src/main/java/ca/marshallasch/veil/ForumStorage.java
+++ b/app/src/main/java/ca/marshallasch/veil/ForumStorage.java
@@ -1,6 +1,6 @@
 package ca.marshallasch.veil;
 
-import android.util.Pair;
+import android.support.v4.util.Pair;
 
 import java.util.List;
 

--- a/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
+++ b/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
@@ -11,11 +11,13 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import ca.marshallasch.veil.comparators.CommentPairComparator;
 import ca.marshallasch.veil.exceptions.TooManyResultsException;
 import ca.marshallasch.veil.proto.DhtProto;
 import ca.marshallasch.veil.utilities.Util;
@@ -279,18 +281,19 @@ public class MemoryStore implements ForumStorage
 
     /**
      * This function will get all the comments that are associated with the given post.
+     * The comments are sorted by the time that they were created.
      *
      * @param postHash he unique SHA256 hash of the post
      * @return the list of results
      */
     @Override
-    @Nullable
+    @NonNull
     public List<Pair<String, DhtProto.Comment>> findCommentsByPost(String postHash)
     {
         ArrayList<DhtProto.DhtWrapper> entries = (ArrayList<DhtProto.DhtWrapper>)hashMap.get(postHash);
 
         if (entries == null) {
-            return null;
+            return new ArrayList<>();
         }
         ArrayList<String> commentHashes = new ArrayList<>();
 
@@ -319,6 +322,8 @@ public class MemoryStore implements ForumStorage
                 e.printStackTrace();
             }
         }
+
+        Collections.sort(comments, new CommentPairComparator());
 
         return comments;
     }
@@ -372,6 +377,10 @@ public class MemoryStore implements ForumStorage
     @Override
     public String insertUser(DhtProto.User user)
     {
+        if (user == null) {
+            return null;
+        }
+
         String hash = Util.generateHash(user.getUuid().getBytes());
         String email = user.getEmail();
         String firstName = user.getFirstName();
@@ -450,11 +459,15 @@ public class MemoryStore implements ForumStorage
     @Nullable
     public List<Pair<String, DhtProto.User>> findUsersByName(String name)
     {
+        if (name == null) {
+            return new ArrayList<>();
+        }
+
         name = name.toLowerCase(Locale.getDefault());
         ArrayList<DhtProto.DhtWrapper> entries = (ArrayList<DhtProto.DhtWrapper>)hashMap.get(Util.generateHash(name.getBytes()));
 
         if (entries == null) {
-            return null;
+            return new ArrayList<>();
         }
         ArrayList<String> userHashes = new ArrayList<>();
 

--- a/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
+++ b/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
@@ -216,7 +216,7 @@ public class MemoryStore implements ForumStorage
         ArrayList<DhtProto.DhtWrapper> entries = (ArrayList<DhtProto.DhtWrapper>)hashMap.get(Util.generateHash(keyword.getBytes()));
 
         if (entries == null) {
-            return null;
+            return new ArrayList<>();
         }
         ArrayList<String> postHashes = new ArrayList<>();
 

--- a/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
+++ b/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
@@ -3,7 +3,7 @@ package ca.marshallasch.veil;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Pair;
+import android.support.v4.util.Pair;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,17 +35,21 @@ import static ca.marshallasch.veil.proto.DhtProto.KeywordType.*;
  */
 public class MemoryStore implements ForumStorage
 {
-    private HashMap<String, List<DhtProto.DhtWrapper>> hashMap;
+    // Made package-private so that it can be accessed for testing.
+    HashMap<String, List<DhtProto.DhtWrapper>> hashMap;
 
 
     private static MemoryStore instance;
     private static final AtomicInteger openCounter = new AtomicInteger();
 
-    private Context context;
-
     private MemoryStore(Context c) {
 
-        context = c;
+        // if there is no context then do not load a persistent file
+        if (c == null) {
+            hashMap = new HashMap<>();
+            return;
+        }
+
         // try loading from mem or create new
         File mapFile = new File(c.getFilesDir(), "HASH_MAP");
         HashMap<String, List<DhtProto.DhtWrapper>> tempMap = null;
@@ -86,7 +90,12 @@ public class MemoryStore implements ForumStorage
     /**
      * This function will update the saved copy of the hash map to the disk.
      */
-    public void close() {
+    public void close(Context context) {
+
+        // if there is no context then don't save the file
+        if (context == null) {
+            return;
+        }
 
         File mapFile = new File(context.getFilesDir(), "HASH_MAP");
 
@@ -114,6 +123,10 @@ public class MemoryStore implements ForumStorage
     @Override
     public String insertPost(DhtProto.Post post)
     {
+        if (post == null) {
+            return null;
+        }
+
         String hash = Util.generateHash(post.toByteArray());
 
         DhtProto.DhtWrapper wrapper = DhtProto.DhtWrapper.newBuilder()

--- a/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
+++ b/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
@@ -258,7 +258,7 @@ public class MemoryStore implements ForumStorage
      * @return the hash  identifying the comment
      */
     @Override
-    public String insertComment(DhtProto.Comment comment, String postHash)
+    public String insertComment(@NonNull DhtProto.Comment comment, @NonNull String postHash)
     {
         String hash = Util.generateHash(comment.toByteArray());
 
@@ -504,9 +504,15 @@ public class MemoryStore implements ForumStorage
      * @param type the type of keyword it is. {@link DhtProto.KeywordType}
      * @return the wraper object to insert into the hashmap
      */
-    private DhtProto.DhtWrapper generateKeyword(String keyword, String dataHash, DhtProto.KeywordType type) {
+    @NonNull
+    private DhtProto.DhtWrapper generateKeyword(@Nullable String keyword, String dataHash, DhtProto.KeywordType type) {
 
-        keyword = keyword.toLowerCase(Locale.getDefault());
+        // according to the protobuf spec, the default value for a string is empty not null
+        if (keyword == null) {
+            keyword = "";
+        } else {
+            keyword = keyword.toLowerCase(Locale.getDefault());
+        }
 
         DhtProto.Keyword keywordObj = DhtProto.Keyword.newBuilder()
                 .setHash(dataHash)

--- a/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
+++ b/app/src/main/java/ca/marshallasch/veil/MemoryStore.java
@@ -44,7 +44,7 @@ public class MemoryStore implements ForumStorage
     private static MemoryStore instance;
     private static final AtomicInteger openCounter = new AtomicInteger();
 
-    private MemoryStore(Context c) {
+    private MemoryStore(@Nullable  Context c) {
 
         // if there is no context then do not load a persistent file
         if (c == null) {
@@ -80,7 +80,7 @@ public class MemoryStore implements ForumStorage
         }
     }
 
-    public static synchronized MemoryStore getInstance(final Context c)
+    public static synchronized MemoryStore getInstance(@Nullable final Context c)
     {
         if (instance == null) {
             instance = new MemoryStore(c);
@@ -92,7 +92,7 @@ public class MemoryStore implements ForumStorage
     /**
      * This function will update the saved copy of the hash map to the disk.
      */
-    public void close(Context context) {
+    public void close(@Nullable Context context) {
 
         // if there is no context then don't save the file
         if (context == null) {

--- a/app/src/main/java/ca/marshallasch/veil/comparators/CommentPairComparator.java
+++ b/app/src/main/java/ca/marshallasch/veil/comparators/CommentPairComparator.java
@@ -1,0 +1,26 @@
+package ca.marshallasch.veil.comparators;
+
+import android.support.v4.util.Pair;
+
+import java.util.Comparator;
+
+import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.utilities.Util;
+
+
+/**
+ * This class is used to sort {@link DhtProto.Comment} objects by the time that they were created.
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-13
+ */
+public class CommentPairComparator implements Comparator<Pair<String, DhtProto.Comment>>
+{
+    @Override
+    public int compare(Pair<String, DhtProto.Comment> a, Pair<String, DhtProto.Comment> b)
+    {
+        long aMillis = Util.timestampToMillis(a.second.getTimestamp());
+        long bMillis = Util.timestampToMillis(b.second.getTimestamp());
+        return (int) (aMillis - bMillis);
+    }
+}

--- a/app/src/main/java/ca/marshallasch/veil/comparators/PostPairComparator.java
+++ b/app/src/main/java/ca/marshallasch/veil/comparators/PostPairComparator.java
@@ -1,0 +1,26 @@
+package ca.marshallasch.veil.comparators;
+
+import android.support.v4.util.Pair;
+
+import java.util.Comparator;
+
+import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.utilities.Util;
+
+
+/**
+ * This class is used to sort {@link DhtProto.Post} objects by the time that they were created.
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-13
+ */
+public class PostPairComparator implements Comparator<Pair<String, DhtProto.Post>>
+{
+    @Override
+    public int compare(Pair<String, DhtProto.Post> a, Pair<String, DhtProto.Post> b)
+    {
+        long aMillis = Util.timestampToMillis(a.second.getTimestamp());
+        long bMillis = Util.timestampToMillis(b.second.getTimestamp());
+        return (int) (aMillis - bMillis);
+    }
+}

--- a/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
+++ b/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
@@ -38,6 +38,15 @@ public class Util
                 .build();
     }
 
+    public static long timestampToMillis(@NonNull Timestamp time) {
+
+        long seconds = time.getSeconds();
+        long nanos = time.getNanos();
+
+        return seconds * 1000 + (nanos / 1000000);
+    }
+
+
     /**
      * Hides Android's soft keyboard.
      *

--- a/app/src/main/proto/dht.proto
+++ b/app/src/main/proto/dht.proto
@@ -10,20 +10,22 @@ import "google/protobuf/timestamp.proto";
  * This identifies what type of data is contained within the DHT wrapper object.
  */
 enum MessageType {
-    USER = 0;
-    POST = 1;
-    COMMENT = 2;
-    KEYWORD = 3;
+    UNKNOWN = 0;
+    USER = 1;
+    POST = 2;
+    COMMENT = 3;
+    KEYWORD = 4;
 
 }
 
 enum KeywordType {
-    TITLE_FULL = 0;
-    TITLE_PARTIAL = 1;
-    TAG = 2;
-    COMMENT_FOR = 3;
-    NAME = 4;
-    EMAIL = 5;
+    UNKOWN = 0;
+    TITLE_FULL = 1;
+    TITLE_PARTIAL = 2;
+    TAG = 3;
+    COMMENT_FOR = 4;
+    NAME = 5;
+    EMAIL = 6;
 }
 
 /**

--- a/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
@@ -180,6 +180,44 @@ public class MemoryStoreTest
     @Test
     public void insertComment()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .setTitle("Post6")
+                .build();
+
+        // if the post is null then the hash should be as well
+        Assert.assertNull(memoryStore.insertPost(null));
+
+        // check that the empty post works
+        String postHash = memoryStore.insertPost(p);
+        Assert.assertNotNull(postHash);
+
+
+        DhtProto.Comment comment = DhtProto.Comment.newBuilder()
+                .setMessage("Comment on the odd post")
+                .build();
+
+        // check that the comment works
+        String hash = memoryStore.insertComment(comment, postHash);
+        Assert.assertNotNull(hash);
+
+        // check that the keyword item for the comment got inserted
+        String hash2 = memoryStore.hashMap.get(postHash).get(1).getKeyword().getHash();
+
+        Assert.assertEquals(DhtProto.KeywordType.COMMENT_FOR, memoryStore.hashMap.get(postHash).get(1).getKeyword().getType());
+        Assert.assertEquals(hash, hash2);
+
+
+        // check that a second comment for the post can be added
+        comment = DhtProto.Comment.newBuilder()
+                .setMessage("Another comment for the post")
+                .build();
+
+        // check that the comment works
+        hash = memoryStore.insertComment(comment, postHash);
+        Assert.assertNotNull(hash);
+
+        Assert.assertEquals(3, memoryStore.hashMap.get(postHash).size());
     }
 
     @Test

--- a/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
@@ -5,6 +5,8 @@ import android.support.v4.util.Pair;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 import ca.marshallasch.veil.exceptions.TooManyResultsException;
 import ca.marshallasch.veil.proto.DhtProto;
 import ca.marshallasch.veil.utilities.Util;
@@ -134,6 +136,45 @@ public class MemoryStoreTest
     @Test
     public void findPostsByKeyword()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .setTitle("Post4")
+                .setMessage("TMessage body does not matter")
+                .addTags("Pop")
+                .addTags("sprite")
+                .build();
+
+
+        // check that the post insert works
+        String hash = memoryStore.insertPost(p);
+        Assert.assertNotNull(hash);
+
+        DhtProto.Post p2 = DhtProto.Post.newBuilder()
+                .setTitle("Post5")
+                .setMessage("TMessage body does not matter")
+                .addTags("coke")
+                .addTags("sprite")
+                .build();
+
+
+        // check that the post insert works
+        hash = memoryStore.insertPost(p2);
+        Assert.assertNotNull(hash);
+
+        // check 2 search results
+        ArrayList<Pair<String, DhtProto.Post>> posts = (ArrayList<Pair<String, DhtProto.Post>>) memoryStore.findPostsByKeyword("sprite");
+        Assert.assertNotNull(posts);
+        Assert.assertEquals(2, posts.size());
+
+        // check 1 search result
+        posts = (ArrayList<Pair<String, DhtProto.Post>>) memoryStore.findPostsByKeyword("coke");
+        Assert.assertNotNull(posts);
+        Assert.assertEquals(1, posts.size());
+
+        // no results
+        posts = (ArrayList<Pair<String, DhtProto.Post>>) memoryStore.findPostsByKeyword("bob marley");
+        Assert.assertNotNull(posts);
+        Assert.assertEquals(0, posts.size());
     }
 
     @Test

--- a/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
@@ -1,0 +1,173 @@
+package ca.marshallasch.veil;
+
+import android.support.v4.util.Pair;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.marshallasch.veil.exceptions.TooManyResultsException;
+import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.utilities.Util;
+
+/**
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-12
+ */
+public class MemoryStoreTest
+{
+    @Test
+    public void getInstance()
+    {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+
+        // make sure that got a value
+        Assert.assertNotNull(memoryStore);
+
+        // make sure that they are the same instance
+        Assert.assertEquals(memoryStore, MemoryStore.getInstance(null));
+    }
+
+    @Test
+    public void insertPost()
+    {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .build();
+
+        // if the post is null then the hash should be as well
+        Assert.assertNull(memoryStore.insertPost(null));
+
+        // check that the empty post works
+        String hash = memoryStore.insertPost(p);
+        Assert.assertNotNull(hash);
+        DhtProto.Post p2 = memoryStore.hashMap.get(hash).get(0).getPost();
+        Assert.assertEquals(p, p2);
+
+
+        p = DhtProto.Post.newBuilder()
+                .setTitle("Post title 1")
+                .build();
+
+        // check that the post works
+        hash = memoryStore.insertPost(p);
+        Assert.assertNotNull(hash);
+
+        // check that the keyword item for the post got inserted
+        String hash2 = memoryStore.hashMap.get(Util.generateHash("post".getBytes())).get(0).getKeyword().getHash();
+        Assert.assertEquals(hash, hash2);
+    }
+
+    @Test
+    public void findPostByHash()
+    {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .setTitle("Post2")
+                .setMessage("This is a nice and short message in the post body")
+                .build();
+
+
+        // check that the post insert works
+        String hash = memoryStore.insertPost(p);
+        Assert.assertNotNull(hash);
+        Pair<String, DhtProto.Post> pair = null;
+
+        try {
+            pair = memoryStore.findPostByHash(hash);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+        Assert.assertEquals(p, pair.second);
+        Assert.assertEquals(hash, pair.first);
+
+
+
+        p = DhtProto.Post.newBuilder()
+                .setTitle("Post3")
+                .setMessage("This is a nice and short message in the post body")
+                .build();
+
+
+        // check that the post insert works
+        hash = memoryStore.insertPost(p);
+        hash = memoryStore.insertPost(p);       // insert a duplicate
+
+        Assert.assertNotNull(hash);
+        pair = null;
+
+        try {
+            pair = memoryStore.findPostByHash(hash);        // this should throw an exception
+        }
+        catch (TooManyResultsException e) {
+            assert true;
+        }
+        Assert.assertNull(pair);
+
+
+        // check null search
+        pair = null;
+        try {
+            pair = memoryStore.findPostByHash(null);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+        Assert.assertNull(pair);
+
+
+        // check no matching key
+        pair = null;
+        try {
+            pair = memoryStore.findPostByHash("abc");
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+        Assert.assertNull(pair);
+    }
+
+    @Test
+    public void findPostsByKeyword()
+    {
+    }
+
+    @Test
+    public void insertComment()
+    {
+    }
+
+    @Test
+    public void findCommentsByPost()
+    {
+    }
+
+    @Test
+    public void findCommentByHash()
+    {
+    }
+
+    @Test
+    public void insertUser()
+    {
+    }
+
+    @Test
+    public void findUserByHash()
+    {
+    }
+
+    @Test
+    public void findUsersByName()
+    {
+    }
+
+    @Test
+    public void updateUser()
+    {
+    }
+}

--- a/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/MemoryStoreTest.java
@@ -6,6 +6,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import ca.marshallasch.veil.exceptions.TooManyResultsException;
 import ca.marshallasch.veil.proto.DhtProto;
@@ -185,10 +187,7 @@ public class MemoryStoreTest
                 .setTitle("Post6")
                 .build();
 
-        // if the post is null then the hash should be as well
-        Assert.assertNull(memoryStore.insertPost(null));
-
-        // check that the empty post works
+        // check that the post works (it is a prereq
         String postHash = memoryStore.insertPost(p);
         Assert.assertNotNull(postHash);
 
@@ -223,30 +222,267 @@ public class MemoryStoreTest
     @Test
     public void findCommentsByPost()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .setTitle("Post7")
+                .build();
+
+        // check that the post works (it is a prereq
+        String postHash = memoryStore.insertPost(p);
+        Assert.assertNotNull(postHash);
+
+
+        DhtProto.Comment comment = DhtProto.Comment.newBuilder()
+                .setMessage("This is the first comment on post 7")
+                .setTimestamp(Util.millisToTimestamp(System.currentTimeMillis()))
+                .build();
+
+        // check that the comment works
+        String hash1 = memoryStore.insertComment(comment, postHash);
+        Assert.assertNotNull(hash1);
+
+        comment = DhtProto.Comment.newBuilder()
+                .setMessage("This is the second comment on post 7")
+                .setTimestamp(Util.millisToTimestamp(System.currentTimeMillis() - 500))
+                .build();
+
+        // check that the comment works
+        String hash2 = memoryStore.insertComment(comment, postHash);
+        Assert.assertNotNull(hash2);
+
+        // done prereqs
+
+        List<Pair<String, DhtProto.Comment>> list = memoryStore.findCommentsByPost(postHash);
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(2, list.size());
+        Assert.assertEquals(hash2, list.get(0).first);      // the second inserted post should be first
+                                                        // since it has an earler timestamp
+        Assert.assertEquals(hash1, list.get(1).first);
+
+
+
+        p = DhtProto.Post.newBuilder()
+                .setTitle("Post8")
+                .build();
+
+        // check that the post works (it is a prereq
+        String postHash2 = memoryStore.insertPost(p);
+        Assert.assertNotNull(postHash2);
+
+        // there should be no comments, empty list
+        list = memoryStore.findCommentsByPost(postHash2);
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(0, list.size());
+
+        // there should be no comments, empty list
+        list = memoryStore.findCommentsByPost(null);
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(0, list.size());
     }
 
     @Test
     public void findCommentByHash()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.Post p = DhtProto.Post.newBuilder()
+                .setTitle("Post9")
+                .build();
+
+        // check that the post works (it is a prereq)
+        String postHash = memoryStore.insertPost(p);
+        Assert.assertNotNull(postHash);
+
+
+        DhtProto.Comment comment = DhtProto.Comment.newBuilder()
+                .setMessage("This is the first comment on post 9")
+                .setTimestamp(Util.millisToTimestamp(System.currentTimeMillis()))
+                .build();
+
+        // check that the comment works
+        String hash1 = memoryStore.insertComment(comment, postHash);
+        Assert.assertNotNull(hash1);
+
+        Pair<String, DhtProto.Comment> pair = null;
+        try {
+            pair = memoryStore.findCommentByHash(hash1);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNotNull(pair);
+        Assert.assertEquals(hash1, pair.first);
+
+
+        // null search
+        pair = null;
+        try {
+            pair = memoryStore.findCommentByHash(null);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNull(pair);
+
+        // no matches
+        pair = null;
+        try {
+            pair = memoryStore.findCommentByHash(postHash);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNull(pair);
     }
 
     @Test
     public void insertUser()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+        DhtProto.User user = DhtProto.User.newBuilder()
+                .setFirstName("bob")
+                .setLastName("John")
+                .setUuid(UUID.randomUUID().toString())
+                .build();
+
+        String hash = memoryStore.insertUser(user);
+        Assert.assertNotNull(hash);
+
+        // check that the user is where it should be
+        DhtProto.User u2 = memoryStore.hashMap.get(hash).get(0).getUser();
+        Assert.assertEquals(user, u2);
+
+        // check that the first name search token is inserted
+        String hash2 = memoryStore.hashMap.get(Util.generateHash("bob".getBytes())).get(0).getKeyword().getHash();
+        Assert.assertEquals(hash, hash2);
+
+
+        // check insert of null user
+        hash = memoryStore.insertUser(null);
+        Assert.assertNull(hash);
     }
 
     @Test
     public void findUserByHash()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+
+        String uuid = UUID.randomUUID().toString();
+        DhtProto.User user = DhtProto.User.newBuilder()
+                .setFirstName("Jakob")
+                .setLastName("Smith")
+                .setUuid(uuid)
+                .build();
+
+        String hash = memoryStore.insertUser(user);
+        Assert.assertNotNull(hash);
+
+        Pair<String, DhtProto.User> pair = null;
+        try {
+            pair = memoryStore.findUserByHash(Util.generateHash(uuid.getBytes()));
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNotNull(pair);
+        Assert.assertEquals(user, pair.second);
+
+        // invalid result
+        pair = null;
+        try {
+            pair = memoryStore.findUserByHash(Util.generateHash("userID".getBytes()));
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNull(pair);
+
+        // invalid hash
+        pair = null;
+        try {
+            pair = memoryStore.findUserByHash(null);
+        }
+        catch (TooManyResultsException e) {
+            e.printStackTrace();
+            assert false;
+        }
+
+        Assert.assertNull(pair);
     }
 
     @Test
     public void findUsersByName()
     {
+        MemoryStore memoryStore = MemoryStore.getInstance(null);
+
+        DhtProto.User user = DhtProto.User.newBuilder()
+                .setFirstName("John")
+                .setLastName("Doe")
+                .setUuid(UUID.randomUUID().toString())
+                .build();
+
+        String hash = memoryStore.insertUser(user);
+        Assert.assertNotNull(hash);
+
+        DhtProto.User user2 = DhtProto.User.newBuilder()
+                .setFirstName("John")
+                .setLastName("Asch")
+                .setUuid(UUID.randomUUID().toString())
+                .build();
+
+        hash = memoryStore.insertUser(user2);
+        Assert.assertNotNull(hash);
+
+        List<Pair<String, DhtProto.User>> list = null;
+        list = memoryStore.findUsersByName("john doe");
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals(user, list.get(0).second);
+
+        // check case insensitivity
+        list = memoryStore.findUsersByName("John Doe");
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals(user, list.get(0).second);
+
+        // check no match
+        list = memoryStore.findUsersByName("john micheal");
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(0, list.size());
+
+        // check null search
+        list = memoryStore.findUsersByName(null);
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(0, list.size());
+
+        // check multiple results
+        list = memoryStore.findUsersByName("john");
+
+        Assert.assertNotNull(list);
+        Assert.assertEquals(2, list.size());
+
     }
 
     @Test
     public void updateUser()
     {
+        // this function is not yet implemented.
+        assert false;
     }
 }

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -1,0 +1,26 @@
+package ca.marshallasch.veil.utilities;
+
+import com.google.protobuf.Timestamp;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-13
+ */
+public class UtilTest
+{
+
+    @Test
+    public void timestampToMillis()
+    {
+        long millis = System.currentTimeMillis();
+
+        Timestamp t = Util.millisToTimestamp(millis);
+
+        Assert.assertEquals(millis, Util.timestampToMillis(t));
+
+    }
+}


### PR DESCRIPTION
closed #42 Added unit tests to the memory store class. Also changed the functionality slightly.
- `findCommentsByPost()` now returns a sorted list by time created
- allow the initializer and closer to accept a `null` Context so that it does not use persistant storage.  
- changed returning null lists to empty lists