### PR TITLE
77 anonymous posts and comments

### DIFF
--- a/app/src/main/java/ca/marshallasch/veil/CommentListAdapter.java
+++ b/app/src/main/java/ca/marshallasch/veil/CommentListAdapter.java
@@ -1,5 +1,6 @@
 package ca.marshallasch.veil;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -24,6 +25,8 @@ import ca.marshallasch.veil.utilities.Util;
  */
 public class CommentListAdapter extends RecyclerView.Adapter<CommentListAdapter.ViewHolder> {
     private List<DhtProto.Comment> commentList;
+
+    private Context context;
 
     /**
      *  This is the cell for each comment in the comment list
@@ -50,8 +53,9 @@ public class CommentListAdapter extends RecyclerView.Adapter<CommentListAdapter.
      *
      * @param comments the list of comments to display
      */
-    public CommentListAdapter(List<DhtProto.Comment> comments){
+    public CommentListAdapter(Context context, List<DhtProto.Comment> comments){
         this.commentList = comments;
+        this.context = context;
     }
 
     public void update(List<DhtProto.Comment> comments) {
@@ -78,9 +82,13 @@ public class CommentListAdapter extends RecyclerView.Adapter<CommentListAdapter.
      */
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, final int position) {
-        holder.authorName.setText(commentList.get(position).getAuthorName());
-        holder.content.setText(commentList.get(position).getMessage());
-        holder.date.setText(Util.timestampToDate(commentList.get(position).getTimestamp()).toString());
+
+        DhtProto.Comment comment = commentList.get(position);
+        String aythorName = comment.getAnonymous() ? context.getString(R.string.anonymous) : comment.getAuthorName();
+
+        holder.authorName.setText(aythorName);
+        holder.content.setText(comment.getMessage());
+        holder.date.setText(Util.timestampToDate(comment.getTimestamp()).toString());
 
     }
 

--- a/app/src/main/java/ca/marshallasch/veil/FragmentAddComment.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentAddComment.java
@@ -5,9 +5,11 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.button.MaterialButton;
 import android.support.design.widget.Snackbar;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -32,6 +34,7 @@ public class FragmentAddComment extends android.support.v4.app.Fragment {
     }
 
     DhtProto.Post postObject;
+    DhtProto.User currentUser;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -53,14 +56,22 @@ public class FragmentAddComment extends android.support.v4.app.Fragment {
             e.printStackTrace();
         }
 
+        currentUser = ((MainActivity) getActivity()).getCurrentUser();
 
         TextView postTitle = view.findViewById(R.id.post_title);
 
         MaterialButton cancelBtn = view.findViewById(R.id.cancel_button);
         MaterialButton postBtn = view.findViewById(R.id.post_comment_btn);
         EditText commentInput = view.findViewById(R.id.post_message);
+        CheckBox anonymousInput = view.findViewById(R.id.anonymous);
 
         postTitle.setText(postObject.getTitle());
+
+        // if I am the author of an anonymous post then default make my comments anonymous.
+        if (postObject.getAnonymous() && currentUser.getUuid().equals(postObject.getAuthorId())) {
+            anonymousInput.setChecked(true);
+            Log.d("ANON", "check box");
+        }
 
 
         //Handle cancel button
@@ -73,6 +84,7 @@ public class FragmentAddComment extends android.support.v4.app.Fragment {
         //Handle post button
         postBtn.setOnClickListener(view1 -> {
             String message = commentInput.getText().toString();
+            boolean anonymous = anonymousInput.isChecked();
 
             // the message can not be empty
             if (message.length() == 0) {
@@ -80,7 +92,7 @@ public class FragmentAddComment extends android.support.v4.app.Fragment {
                 return;
             }
 
-            DhtProto.Comment comment = Util.createComment(message, ((MainActivity) getActivity()).getCurrentUser());
+            DhtProto.Comment comment = Util.createComment(message, currentUser, anonymous);
 
             // save to the data store
             DataStore.getInstance(getActivity()).saveComment(comment, postObject);

--- a/app/src/main/java/ca/marshallasch/veil/FragmentCreatePost.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentCreatePost.java
@@ -10,6 +10,7 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
 import android.widget.EditText;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ public class FragmentCreatePost extends Fragment
     private EditText titleInput;
     private EditText messageInput;
     private EditText tagsInput;
+    private CheckBox anonymousInput;
 
     DhtProto.User currentUser;
 
@@ -45,6 +47,7 @@ public class FragmentCreatePost extends Fragment
         titleInput = view.findViewById(R.id.title_text_edit);
         messageInput = view.findViewById(R.id.post_message);
         tagsInput = view.findViewById(R.id.tags_text_edit);
+        anonymousInput = view.findViewById(R.id.anonymous);
 
         MaterialButton submit = view.findViewById(R.id.save);
         MaterialButton cancel = view.findViewById(R.id.cancel_button);
@@ -80,6 +83,7 @@ public class FragmentCreatePost extends Fragment
         String tags = tagsInput.getText().toString();
         String title = titleInput.getText().toString();
         String message = messageInput.getText().toString();
+        boolean anonymous = anonymousInput.isChecked();
 
         // check input
         if (title.length() == 0 || message.length() == 0 || currentUser == null) {
@@ -88,9 +92,7 @@ public class FragmentCreatePost extends Fragment
 
         ArrayList<String> tagList = new ArrayList<>(Arrays.asList(tags.split(",")));
 
-        DhtProto.Post post = Util.createPost(title, message, currentUser, tagList);
-
-
+        DhtProto.Post post = Util.createPost(title, message, currentUser, tagList, anonymous);
 
         DataStore dataStore = DataStore.getInstance(getContext());
 

--- a/app/src/main/java/ca/marshallasch/veil/FragmentViewPost.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentViewPost.java
@@ -42,7 +42,6 @@ public class FragmentViewPost extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_view_post, container, false);
 
-
         getActivity().getSupportFragmentManager().addOnBackStackChangedListener(listener);
 
         //retrieve passed bundle from the PostListAdapter Class
@@ -75,8 +74,11 @@ public class FragmentViewPost extends Fragment {
             viewTitle.setText(postObject.getTitle());
             viewContent.setText(postObject.getMessage());
             viewPostHash.setText(postObject.getUuid());
-            viewAuthorName.setText(postObject.getAuthorName());
             viewDate.setText(Util.timestampToDate(postObject.getTimestamp()).toString());
+
+            // check if the post is anonymous before displaying it.
+            String authorName = postObject.getAnonymous() ? getString(R.string.anonymous) : postObject.getAuthorName();
+            viewAuthorName.setText(authorName);
         }
 
         //recycler view logic for displaying comments
@@ -90,7 +92,7 @@ public class FragmentViewPost extends Fragment {
         //Setting the recycler view to hold comments for the post
         LinearLayoutManager linearLayoutManager  = new LinearLayoutManager(activity);
         recyclerView.setLayoutManager(linearLayoutManager);
-        listAdapter = new CommentListAdapter(comments);
+        listAdapter = new CommentListAdapter(activity, comments);
         recyclerView.setAdapter(listAdapter);
 
         //click listener for comment bar

--- a/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
+++ b/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
@@ -115,6 +115,7 @@ public class Util
     /**
      * This will create a new post object with the <code>UUID</code> field set to the hash of the
      * object. To verify the the hash of the object, remove the uuid field then hash the post.
+     * This will set the anonymous field to false
      *
      * @param title string title of the post
      * @param message the message body of the post
@@ -124,6 +125,22 @@ public class Util
      */
     public static DhtProto.Post createPost(String title, String message, @NonNull DhtProto.User author, @Nullable List<String> tags) {
 
+        return createPost(title, message, author, tags, false);
+    }
+
+    /**
+     * This will create a new post object with the <code>UUID</code> field set to the hash of the
+     * object. To verify the the hash of the object, remove the uuid field then hash the post.
+     *
+     * @param title string title of the post
+     * @param message the message body of the post
+     * @param author the {@link ca.marshallasch.veil.proto.DhtProto.User} object
+     * @param tags a list of tag strings
+     * @param anonymous whether or not the authors name will be displayed when it is shown.
+     * @return a post object
+     */
+    public static DhtProto.Post createPost(String title, String message, @NonNull DhtProto.User author, @Nullable List<String> tags, boolean anonymous) {
+
         DhtProto.Post.Builder postBuilder = DhtProto.Post.newBuilder();
 
         // set attributes
@@ -132,6 +149,7 @@ public class Util
         postBuilder.setAuthorName(author.getFirstName() + " " + author.getLastName());
         postBuilder.setAuthorId(author.getUuid());
         postBuilder.setTimestamp(millisToTimestamp(System.currentTimeMillis()));
+        postBuilder.setAnonymous(anonymous);
 
         // add the tags if there are any
         if (tags != null) {
@@ -146,7 +164,20 @@ public class Util
                 .build();
 
         return post;
+    }
 
+    /**
+     * Create a new comment object, that is not assigned to a specific post.
+     * Note that this does not set the postID field, and the hash is made with the field unset.
+     * This will set anonymous to false.
+     *
+     * @param message the body of the comment
+     * @param author the author who wrote the comment
+     * @return a comment object with the postID field unset
+     */
+    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author) {
+
+        return createComment(message, author, null, false);
     }
 
     /**
@@ -155,11 +186,27 @@ public class Util
      *
      * @param message the body of the comment
      * @param author the author who wrote the comment
+     * @param anonymous if the post is anonymous or not
      * @return a comment object with the postID field unset
      */
-    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author) {
+    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author, boolean anonymous) {
 
-        return createComment(message, author, null);
+        return createComment(message, author, null, anonymous);
+    }
+
+    /**
+     * Create a new comment object, that is not assigned to a specific post.
+     * Note that this does not set the postID field, and the hash is made with the field unset.
+     * This will set anonymous to false.
+     *
+     * @param message the body of the comment
+     * @param author the author who wrote the comment
+     * @param postHash the postID that it belongs to
+     * @return a comment object with the postID field set
+     */
+    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author, @Nullable String postHash) {
+
+        return createComment(message, author, postHash, false);
     }
 
     /**
@@ -169,9 +216,10 @@ public class Util
      * @param message the body of the comment
      * @param author the author who wrote the comment
      * @param postHash the postID that it belongs to
+     * @param anonymous if the post is anonymous or not
      * @return a comment object with the postID field set
      */
-    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author, @Nullable String postHash) {
+    public static DhtProto.Comment createComment(@NonNull String message, @NonNull DhtProto.User author, @Nullable String postHash, boolean anonymous) {
 
         // set attributed
         DhtProto.Comment.Builder builder = DhtProto.Comment.newBuilder();
@@ -179,6 +227,7 @@ public class Util
         builder.setAuthorName(author.getFirstName() + " " + author.getLastName());
         builder.setAuthorId(author.getUuid());
         builder.setTimestamp(millisToTimestamp(System.currentTimeMillis()));
+        builder.setAnonymous(anonymous);
 
         if (postHash != null) {
             builder.setPostId(postHash);
@@ -195,6 +244,4 @@ public class Util
 
         return comment;
     }
-
-
 }

--- a/app/src/main/proto/dht.proto
+++ b/app/src/main/proto/dht.proto
@@ -72,6 +72,7 @@ message Post {
     string message = 5;
     google.protobuf.Timestamp timestamp = 6;   // when the post was created
     repeated string tags = 7;
+    bool anonymous = 8;         // if this is set then do not show the username
 }
 
 /**
@@ -86,6 +87,7 @@ message Comment {
     string author_id = 4;      // this is unique to each user
     string message = 5;
     google.protobuf.Timestamp timestamp = 6;   // when the comment was created
+    bool anonymous = 8;         // if this is set then do not show the username
 }
 
 /**

--- a/app/src/main/res/layout/fragment_add_comment.xml
+++ b/app/src/main/res/layout/fragment_add_comment.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
+                                             xmlns:tools="http://schemas.android.com/tools"
+                                             android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <ScrollView
@@ -83,6 +84,17 @@
                 app:layout_constraintHorizontal_bias="1.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/post_message" />
+
+            <CheckBox
+                android:id="@+id/anonymous"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/anonymous"
+                app:layout_constraintStart_toStartOf="@+id/post_message"
+                app:layout_constraintTop_toBottomOf="@+id/post_message"/>
 
         </android.support.constraint.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_create_post.xml
+++ b/app/src/main/res/layout/fragment_create_post.xml
@@ -91,7 +91,7 @@
                 android:layout_marginRight="16dp"
                 android:layout_marginStart="16dp"
                 android:hint="@string/tags_hint"
-                app:layout_constraintBottom_toTopOf="@+id/post_message"
+                app:layout_constraintBottom_toTopOf="@+id/anonymous"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="1.0"
                 app:layout_constraintStart_toStartOf="parent"
@@ -133,6 +133,15 @@
                 app:backgroundTint="@color/colorPrimary"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
+
+            <CheckBox
+                android:id="@+id/anonymous"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/anonymous"
+                app:layout_constraintBottom_toTopOf="@+id/post_message"
+                app:layout_constraintStart_toStartOf="@+id/post_message"/>
 
         </android.support.constraint.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,7 @@
     <string name="comment_hint">Add a comment about the post.</string>
     <string name="post">Post</string>
 
+    <string name="anonymous">Anonymous</string>
+
+
 </resources>


### PR DESCRIPTION
closes #77. Added the ability to create anonymous posts and comments, It will not display the name of the author if it is flagged as anonymous. This will continue to work on a backwards compatible way. When an anonymous post / comment is on a device that does not support anonymous posts then the author will be visible. Old posts are forwards compatible.

If you are creating a new comment and you are the author of the original anonymous post then the comment will be default set to be anonymous.