### PR TITLE
79 refresh data

### DIFF
--- a/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
@@ -70,6 +70,8 @@ public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLay
 
         refreshLayout = view.findViewById(R.id.swiperefresh);
 
+        refreshLayout.setOnRefreshListener(this);
+
         // register receiver to be notified when the data changes
         localBroadcastManager = LocalBroadcastManager.getInstance(activity);
         localBroadcastManager.registerReceiver(localReceiver, new IntentFilter(MainActivity.NEW_DATA_BROADCAST));
@@ -100,6 +102,11 @@ public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLay
 
             // request an update from everyone
             for (MeshId peer: peers) {
+
+                // do not ask myself for info
+                if (peer.equals(manager.getUuid())) {
+                    continue;
+                }
                 manager.sendDataReliable(peer, MainActivity.DATA_PORT, dataRequest.toByteArray());
             }
 
@@ -123,6 +130,7 @@ public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLay
                 List<DhtProto.Post> posts = DataStore.getInstance(context).getKnownPosts();
                 postListAdapter.update(posts);
                 postListAdapter.notifyDataSetChanged();
+                refreshLayout.setRefreshing(false);
 
             }
         }

--- a/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
@@ -4,10 +4,12 @@ import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -40,6 +42,7 @@ public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLay
 
     private PostListAdapter postListAdapter;
     private SwipeRefreshLayout refreshLayout;
+    private LocalBroadcastManager localBroadcastManager;
 
     public FragmentDiscoverForums() {
         // Required empty public constructor
@@ -67,10 +70,23 @@ public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLay
 
         refreshLayout = view.findViewById(R.id.swiperefresh);
 
+        // register receiver to be notified when the data changes
+        localBroadcastManager = LocalBroadcastManager.getInstance(activity);
+        localBroadcastManager.registerReceiver(localReceiver, new IntentFilter(MainActivity.NEW_DATA_BROADCAST));
+
+
 
         return view;
     }
 
+    @Override
+    public void onDestroyView()
+    {
+        super.onDestroyView();
+
+        // unregister receiver
+        localBroadcastManager.unregisterReceiver(localReceiver);
+    }
 
     @Override
     public void onRefresh()

--- a/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
+++ b/app/src/main/java/ca/marshallasch/veil/FragmentDiscoverForums.java
@@ -1,19 +1,29 @@
 package ca.marshallasch.veil;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.List;
+import java.util.Set;
 
 import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.proto.Sync;
+import io.left.rightmesh.id.MeshId;
+import io.left.rightmesh.mesh.MeshManager;
+import io.left.rightmesh.util.RightMeshException;
 
 /**
  *
@@ -25,7 +35,11 @@ import ca.marshallasch.veil.proto.DhtProto;
  * @version 1.0
  * @since 2018-05-31
  */
-public class FragmentDiscoverForums extends Fragment {
+public class FragmentDiscoverForums extends Fragment implements  SwipeRefreshLayout.OnRefreshListener {
+
+
+    private PostListAdapter postListAdapter;
+    private SwipeRefreshLayout refreshLayout;
 
     public FragmentDiscoverForums() {
         // Required empty public constructor
@@ -33,7 +47,8 @@ public class FragmentDiscoverForums extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)  {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
 
         View view = inflater.inflate(R.layout.fragment_discover_forums, container,false);
 
@@ -46,9 +61,55 @@ public class FragmentDiscoverForums extends Fragment {
 
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(activity);
         recyclerView.setLayoutManager(linearLayoutManager);
-        RecyclerView.Adapter recyclerAdapter = new PostListAdapter(posts, activity);
-        recyclerView.setAdapter(recyclerAdapter);
+        postListAdapter = new PostListAdapter(posts, activity);
+        recyclerView.setAdapter(postListAdapter);
+
+
+        refreshLayout = view.findViewById(R.id.swiperefresh);
+
 
         return view;
     }
+
+
+    @Override
+    public void onRefresh()
+    {
+        Log.d("REFRESH", "refreshing the data set");
+        try {
+            MeshManager manager = ((MainActivity) getActivity()).meshManager;
+            Set<MeshId> peers = manager.getPeers(MainActivity.DATA_PORT);
+
+            Sync.Message dataRequest = Sync.Message.newBuilder().setType(Sync.SyncMessageType.REQUEST_DATA).build();
+
+            // request an update from everyone
+            for (MeshId peer: peers) {
+                manager.sendDataReliable(peer, MainActivity.DATA_PORT, dataRequest.toByteArray());
+            }
+
+            postListAdapter.notifyDataSetChanged();
+
+        }
+        catch (RightMeshException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private final  BroadcastReceiver localReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent)
+        {
+
+            String action = intent.getAction();
+
+            if (action.equals(MainActivity.NEW_DATA_BROADCAST)) {
+
+                List<DhtProto.Post> posts = DataStore.getInstance(context).getKnownPosts();
+                postListAdapter.update(posts);
+                postListAdapter.notifyDataSetChanged();
+
+            }
+        }
+    };
+
 }

--- a/app/src/main/java/ca/marshallasch/veil/MainActivity.java
+++ b/app/src/main/java/ca/marshallasch/veil/MainActivity.java
@@ -259,6 +259,7 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
             LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         } else if (type == Sync.SyncMessageType.REQUEST_DATA) {
 
+            Log.d("DATA_REQUEST", "recived request for data");
             // if someone sent a message asking for data send a responce with everything
 
             Sync.HashData hashData = dataStore.getDataStore();
@@ -297,7 +298,15 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
         // Update peer list.
         PeerChangedEvent event = (PeerChangedEvent) e;
         if (event.state != REMOVED) {
+
+            if (event.peerUuid.equals(meshManager.getUuid())) {
+                Log.d("FOUND", "found loopback: " + event.peerUuid);
+                return;
+            }
+
             Log.d("FOUND", "found user: " + event.peerUuid);
+
+
 
             Sync.HashData hashData = dataStore.getDataStore();
             Sync.MappingMessage mappingMessage =  dataStore.getDatabase();

--- a/app/src/main/java/ca/marshallasch/veil/MainActivity.java
+++ b/app/src/main/java/ca/marshallasch/veil/MainActivity.java
@@ -1,10 +1,12 @@
 package ca.marshallasch.veil;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
@@ -32,7 +34,9 @@ import static io.left.rightmesh.mesh.MeshManager.REMOVED;
 public class MainActivity extends AppCompatActivity implements MeshStateListener
 {
 
-    private static final int DATA_PORT = 9182;
+    public static final String NEW_DATA_BROADCAST = "ca.marshallasch.veil.NEW_DATA_BROADCAST";
+
+    public static final int DATA_PORT = 9182;
     // private static final int DISCOVERY_PORT = 9183;       // This port will be used for the DHT
                                                             // to keep all of that traffic separate
 
@@ -223,7 +227,8 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
      *
      * @param e event object from mesh
      */
-    private void handleDataReceived(RightMeshEvent e) {
+    private void handleDataReceived(RightMeshEvent e)
+    {
         // TODO: 2018-05-28 Add in logic to handle the incoming data
         final DataReceivedEvent event = (DataReceivedEvent) e;
 
@@ -240,11 +245,43 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
 
         if (type == Sync.SyncMessageType.HASH_DATA) {
 
-            Log.d("DATA_RECEIVE",  message.getData().toString());
+            Log.d("DATA_RECEIVE", message.getData().toString());
             dataStore.syncData(message.getData());
         } else if (type == Sync.SyncMessageType.MAPPING_MESSAGE) {
-            Log.d("DATA_RECEIVE_MAP",  message.getMapping().toString());
+            Log.d("DATA_RECEIVE_MAP", message.getMapping().toString());
+
             dataStore.syncDatabase(message.getMapping());
+
+            // notify anyone interested that the data store has been updated.
+            Intent intent = new Intent(NEW_DATA_BROADCAST);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        } else if (type == Sync.SyncMessageType.REQUEST_DATA) {
+
+            // if someone sent a message asking for data send a responce with everything
+
+            Sync.HashData hashData = dataStore.getDataStore();
+            Sync.MappingMessage mappingMessage = dataStore.getDatabase();
+
+            // send messages to the peer.
+            Sync.Message toSend = Sync.Message.newBuilder()
+                    .setType(Sync.SyncMessageType.HASH_DATA)
+                    .setData(hashData)
+                    .build();
+
+            try {
+                meshManager.sendDataReliable(event.peerUuid, DATA_PORT, toSend.toByteArray());
+
+                toSend = Sync.Message.newBuilder()
+                        .setType(Sync.SyncMessageType.MAPPING_MESSAGE)
+                        .setMapping(mappingMessage)
+                        .build();
+
+                meshManager.sendDataReliable(event.peerUuid, DATA_PORT, toSend.toByteArray());
+
+            }
+            catch (RightMeshException e1) {
+                e1.printStackTrace();
+            }
         }
     }
 
@@ -260,7 +297,6 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
         if (event.state != REMOVED) {
             Log.d("FOUND", "found user: " + event.peerUuid);
 
-
             Sync.HashData hashData = dataStore.getDataStore();
             Sync.MappingMessage mappingMessage =  dataStore.getDatabase();
 
@@ -273,16 +309,11 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
                         .build();
                 meshManager.sendDataReliable(event.peerUuid, DATA_PORT, message.toByteArray());
 
-                Log.d("DATA_SEND",  message.getData().toString());
-
                 message = Sync.Message.newBuilder()
                         .setType(Sync.SyncMessageType.MAPPING_MESSAGE)
                         .setMapping(mappingMessage)
                         .build();
                 meshManager.sendDataReliable(event.peerUuid, DATA_PORT, message.toByteArray());
-
-                Log.d("DATA_SEND_MAP",  message.getMapping().toString());
-
             }
             catch (RightMeshException e1) {
                 e1.printStackTrace();

--- a/app/src/main/java/ca/marshallasch/veil/PostListAdapter.java
+++ b/app/src/main/java/ca/marshallasch/veil/PostListAdapter.java
@@ -56,6 +56,15 @@ public class PostListAdapter extends RecyclerView.Adapter<PostListAdapter.ViewHo
         this.posts = posts;
     }
 
+
+    /**
+     * This will refresh the posts that are in the list.
+     * @param posts the new list of posts to display.
+     */
+    public void update(List<DhtProto.Post> posts) {
+        this.posts = posts;
+    }
+
     /**
      * Creates the cell view if there is no existing cells available for recycler view can reuse.
      * @param parent the list that it belongs to

--- a/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
+++ b/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
@@ -220,11 +220,13 @@ public class Util
      * @return the password if there is a known one otherwise null
      */
     @Nullable
-    public static String getKnownPassword(Activity activity) {
+    public static String getKnownPassword(Activity activity)
+    {
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
 
         return sharedPref.getString(activity.getString(R.string.pref_passwords), null);
+    }
 
     /**
      * Create a new comment object, that is not assigned to a specific post.

--- a/app/src/main/proto/sync.proto
+++ b/app/src/main/proto/sync.proto
@@ -10,6 +10,7 @@ import "dht.proto";
 enum SyncMessageType {
     MAPPING_MESSAGE = 0;
     HASH_DATA = 1;
+    REQUEST_DATA = 2;
 }
 
 // message wrapper for all messages so that the correct one can be recreated

--- a/app/src/main/res/layout/fragment_discover_forums.xml
+++ b/app/src/main/res/layout/fragment_discover_forums.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<android.support.v4.widget.SwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swiperefresh"
+
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -10,4 +12,4 @@
         android:layout_height="match_parent"/>
 
 
-</RelativeLayout>
+</android.support.v4.widget.SwipeRefreshLayout>


### PR DESCRIPTION
closes #79 Added the ability to manually refresh the list of posts without requiring that a peer discovered event happens.