### PR TITLE
83 more unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 protobuf {
@@ -102,6 +108,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    testImplementation "org.robolectric:robolectric:4.0-alpha-2"
+
 
 
 }

--- a/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
+++ b/app/src/main/java/ca/marshallasch/veil/utilities/Util.java
@@ -95,6 +95,11 @@ public class Util
     @Nullable
     public static String generateHash(byte[] data) {
 
+        //handle null data
+        if (data == null){
+            return null;
+        }
+
         byte[] hash;
         StringBuilder hashStr = new StringBuilder();
         try {

--- a/app/src/test/java/ca/marshallasch/veil/comparators/CommentComparatorTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/comparators/CommentComparatorTest.java
@@ -1,0 +1,42 @@
+package ca.marshallasch.veil.comparators;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.utilities.Util;
+
+/**
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-29
+ */
+public class CommentComparatorTest
+{
+
+    @Test
+    public void compare()
+    {
+        long millis = System.currentTimeMillis();
+        DhtProto.Comment a = DhtProto.Comment.newBuilder()
+                .setTimestamp(Util.millisToTimestamp(millis))
+                .build();
+
+
+        DhtProto.Comment b = DhtProto.Comment.newBuilder()
+                .setTimestamp(Util.millisToTimestamp(millis))
+                .build();
+
+        DhtProto.Comment c = DhtProto.Comment.newBuilder()
+                .setTimestamp(Util.millisToTimestamp(millis - 10))
+                .build();
+
+
+        CommentComparator comparator = new CommentComparator();
+
+        Assert.assertEquals(0, comparator.compare(a, b));
+        Assert.assertEquals(-10, comparator.compare(a, c));
+        Assert.assertEquals(10, comparator.compare(c, a));
+
+    }
+}

--- a/app/src/test/java/ca/marshallasch/veil/comparators/EntryComparatorTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/comparators/EntryComparatorTest.java
@@ -1,0 +1,76 @@
+package ca.marshallasch.veil.comparators;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.marshallasch.veil.proto.DhtProto;
+import ca.marshallasch.veil.utilities.Util;
+
+/**
+ * @author Marshall Asch
+ * @version 1.0
+ * @since 2018-06-29
+ */
+public class EntryComparatorTest
+{
+
+    DhtProto.User author = DhtProto.User.newBuilder()
+            .setFirstName("Marshall")
+            .setLastName("Asch")
+            .setEmail("maasch@rogers.com")
+            .setUuid("userID")
+            .setTimestamp(Util.millisToTimestamp(System.currentTimeMillis()))
+            .build();
+
+    @Test
+    public void entryEquals()
+    {
+        DhtProto.Post postA = Util.createPost("Awsome Post", "Message of the post", author, null);
+        DhtProto.Post postB = Util.createPost("Second non match", "Message of the post", author, null);
+        DhtProto.Post postC = DhtProto.Post.newBuilder(postA).build();
+
+        DhtProto.Comment commentA = Util.createComment("Good comment", author);
+
+        DhtProto.Comment commentB = Util.createComment("Second comment", author);
+
+
+        DhtProto.DhtWrapper wrapperA = DhtProto.DhtWrapper.newBuilder()
+                .setType(DhtProto.MessageType.POST)
+                .setPost(postA)
+                .build();
+
+        DhtProto.DhtWrapper wrapperB = DhtProto.DhtWrapper.newBuilder()
+                .setType(DhtProto.MessageType.POST)
+                .setPost(postB)
+                .build();
+
+        DhtProto.DhtWrapper wrapperC = DhtProto.DhtWrapper.newBuilder()
+                .setType(DhtProto.MessageType.POST)
+                .setPost(postC)
+                .build();
+
+        DhtProto.DhtWrapper wrapperD = DhtProto.DhtWrapper.newBuilder()
+                .setType(DhtProto.MessageType.COMMENT)
+                .setComment(commentA)
+                .build();
+
+        DhtProto.DhtWrapper wrapperE = DhtProto.DhtWrapper.newBuilder()
+                .setType(DhtProto.MessageType.COMMENT)
+                .setComment(commentB)
+                .build();
+
+        Assert.assertTrue(EntryComparator.entryEquals(null, null));
+        Assert.assertFalse(EntryComparator.entryEquals(wrapperA, null));
+        Assert.assertFalse(EntryComparator.entryEquals(wrapperA, wrapperB));
+        Assert.assertTrue(EntryComparator.entryEquals(wrapperA, wrapperC));
+
+
+        // compare a comment to a post
+        Assert.assertFalse(EntryComparator.entryEquals(wrapperA, wrapperD));
+        Assert.assertFalse(EntryComparator.entryEquals(wrapperE, wrapperD));
+
+
+
+
+    }
+}

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -5,6 +5,10 @@ import com.google.protobuf.Timestamp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Date;
+
+import ca.marshallasch.veil.proto.DhtProto;
+
 /**
  * @author Marshall Asch
  * @version 1.0
@@ -12,6 +16,13 @@ import org.junit.Test;
  */
 public class UtilTest
 {
+    DhtProto.User author = DhtProto.User.newBuilder()
+            .setFirstName("Marshall")
+            .setLastName("Asch")
+            .setEmail("maasch@rogers.com")
+            .setUuid("userID")
+            .setTimestamp(Util.millisToTimestamp(System.currentTimeMillis()))
+            .build();
 
     @Test
     public void timestampToMillis()
@@ -21,6 +32,63 @@ public class UtilTest
         Timestamp t = Util.millisToTimestamp(millis);
 
         Assert.assertEquals(millis, Util.timestampToMillis(t));
+    }
 
+    @Test
+    public void timestampToDate()
+    {
+        Date date = new Date();
+        Timestamp timestamp = Util.millisToTimestamp(date.getTime());
+
+        Assert.assertEquals(date, Util.timestampToDate(timestamp));
+
+    }
+
+
+    @Test
+    public void createComment()
+    {
+
+        DhtProto.Comment comment = Util.createComment("This is the message", author);
+
+        Assert.assertNotNull(comment);
+        Assert.assertEquals("Marshall Asch", comment.getAuthorName());
+        Assert.assertEquals("userID", comment.getAuthorId());
+        Assert.assertEquals("This is the message", comment.getMessage());
+        Assert.assertEquals(false, comment.getAnonymous());
+        Assert.assertEquals("", comment.getPostId());
+
+        // test no post hash set
+        comment = Util.createComment("This is the second message", author, true);
+
+        Assert.assertNotNull(comment);
+        Assert.assertEquals("Marshall Asch", comment.getAuthorName());
+        Assert.assertEquals("userID", comment.getAuthorId());
+        Assert.assertEquals("This is the second message", comment.getMessage());
+        Assert.assertEquals(true, comment.getAnonymous());
+        Assert.assertEquals("", comment.getPostId());
+
+        // test set postHash
+        comment = Util.createComment("This is the third message", author, "postHash");
+
+        Assert.assertNotNull(comment);
+        Assert.assertEquals("Marshall Asch", comment.getAuthorName());
+        Assert.assertEquals("userID", comment.getAuthorId());
+        Assert.assertEquals("This is the third message", comment.getMessage());
+        Assert.assertEquals(false, comment.getAnonymous());
+        Assert.assertEquals("postHash", comment.getPostId());
+
+        // test set postHash and anonymous
+        comment = Util.createComment("This is the fourth message", author, "postHash", true);
+
+        Assert.assertNotNull(comment);
+        Assert.assertEquals("Marshall Asch", comment.getAuthorName());
+        Assert.assertEquals("userID", comment.getAuthorId());
+        Assert.assertEquals("This is the fourth message", comment.getMessage());
+        Assert.assertEquals(true, comment.getAnonymous());
+        Assert.assertEquals("postHash", comment.getPostId());
+
+
+        // annotations say null can not be given for the message or the author
     }
 }

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -202,8 +202,8 @@ public class UtilTest
         Assert.assertNotEquals(Util.generateHash(testData), Util.generateHash(testData2));
         //Assert null for null input
         Assert.assertNull(Util.generateHash(null));
-        //Assert null for empty byte array inpu
-        Assert.assertNull(Util.generateHash("".getBytes()));
+        //Assert non-null for empty byte array input
+        Assert.assertNotNull(Util.generateHash("".getBytes()));
     }
 
     @Test
@@ -238,9 +238,6 @@ public class UtilTest
         for(int i = 0; i < testTags.size(); i++){
             Assert.assertEquals(post.getTags(i), testTags.get(i));
         }
-
-
-
     }
 
 }

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -227,16 +227,16 @@ public class UtilTest
         //Assert that post exists
         Assert.assertNotNull(post);
         //Assert that title equals
-        Assert.assertEquals(post.getTitle(), title);
+        Assert.assertEquals(title, post.getTitle());
         //Assert that author names equal
-        Assert.assertEquals(post.getAuthorName(), testUser.getFirstName() + " " + testUser.getLastName());
+        Assert.assertEquals(testUser.getFirstName() + " " + testUser.getLastName(),post.getAuthorName());
         //Assert that Author UUID equals
-        Assert.assertEquals(post.getAuthorId(), testUser.getUuid());
+        Assert.assertEquals(testUser.getUuid(), post.getAuthorId());
         //Assert that tags counts are equal
-        Assert.assertEquals(post.getTagsCount(), testTags.size());
+        Assert.assertEquals(testTags.size(), post.getTagsCount());
         //Assert that each tag is equal
         for(int i = 0; i < testTags.size(); i++){
-            Assert.assertEquals(post.getTags(i), testTags.get(i));
+            Assert.assertEquals(testTags.get(i),post.getTags(i));
         }
     }
 

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -17,6 +17,12 @@ import ca.marshallasch.veil.MainActivity;
 import ca.marshallasch.veil.R;
 import ca.marshallasch.veil.proto.DhtProto;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import ca.marshallasch.veil.proto.DhtProto;
+
 /**
  * @author Marshall Asch
  * @version 1.0
@@ -182,4 +188,59 @@ public class UtilTest
         Assert.assertNull(userName);
         Assert.assertNull(password);
     }
+
+    @Test
+    public void generateHash(){
+        String strTestData = "Test Data";
+        String strTestData2 = "Test Data 2";
+        byte[] testData = strTestData.getBytes();
+        byte[] testData2 = strTestData2.getBytes();
+
+        //Assert that hashing is consistent for same data
+        Assert.assertEquals(Util.generateHash(testData), Util.generateHash(testData));
+        //Assert that hashing is different for different data
+        Assert.assertNotEquals(Util.generateHash(testData), Util.generateHash(testData2));
+        //Assert null for null input
+        Assert.assertNull(Util.generateHash(null));
+        //Assert null for empty byte array inpu
+        Assert.assertNull(Util.generateHash("".getBytes()));
+    }
+
+    @Test
+    public void createPost(){
+        String title = "Test Title";
+        String message = "Test message";
+        DhtProto.User testUser = DhtProto.User.newBuilder()
+                .setEmail("test@gmail.com")
+                .setFirstName("John")
+                .setLastName("Doe")
+                .setUuid(UUID.randomUUID().toString())
+                .build();
+
+        List<String> testTags = new ArrayList<>();
+        testTags.add("sample tag 1");
+        testTags.add("sample tag 2");
+
+        //create post w/ tags for testing
+        DhtProto.Post post = Util.createPost(title, message, testUser, testTags);
+
+        //Assert that post exists
+        Assert.assertNotNull(post);
+        //Assert that title equals
+        Assert.assertEquals(post.getTitle(), title);
+        //Assert that author names equal
+        Assert.assertEquals(post.getAuthorName(), testUser.getFirstName() + " " + testUser.getLastName());
+        //Assert that Author UUID equals
+        Assert.assertEquals(post.getAuthorId(), testUser.getUuid());
+        //Assert that tags counts are equal
+        Assert.assertEquals(post.getTagsCount(), testTags.size());
+        //Assert that each tag is equal
+        for(int i = 0; i < testTags.size(); i++){
+            Assert.assertEquals(post.getTags(i), testTags.get(i));
+        }
+
+
+
+    }
+
 }

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -1,12 +1,20 @@
 package ca.marshallasch.veil.utilities;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
 import com.google.protobuf.Timestamp;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.Date;
 
+import ca.marshallasch.veil.MainActivity;
+import ca.marshallasch.veil.R;
 import ca.marshallasch.veil.proto.DhtProto;
 
 /**
@@ -14,6 +22,7 @@ import ca.marshallasch.veil.proto.DhtProto;
  * @version 1.0
  * @since 2018-06-13
  */
+@RunWith(RobolectricTestRunner.class)
 public class UtilTest
 {
     DhtProto.User author = DhtProto.User.newBuilder()
@@ -90,5 +99,87 @@ public class UtilTest
 
 
         // annotations say null can not be given for the message or the author
+    }
+
+
+    @Test
+    public void rememberUserName()
+    {
+        MainActivity activity = Robolectric.setupActivity(MainActivity.class);
+
+
+        Util.rememberUserName(activity, "userName", "Password");
+
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+
+        String userName = sharedPref.getString(activity.getString(R.string.pref_username), null);
+        String password = sharedPref.getString(activity.getString(R.string.pref_passwords), null);
+
+        Assert.assertEquals("userName", userName);
+        Assert.assertEquals("Password", password);
+    }
+
+    @Test
+    public void getKnownUsername()
+    {
+        MainActivity activity = Robolectric.setupActivity(MainActivity.class);
+
+
+        // make sure the shared preferences has a value
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+        SharedPreferences.Editor editor = sharedPref.edit();
+
+        editor.putString(activity.getString(R.string.pref_username), "UserName1");
+        editor.apply();
+
+        String userName = Util.getKnownUsername(activity);
+
+        Assert.assertEquals("UserName1", userName);
+    }
+
+
+    @Test
+    public void getKnownPassword()
+    {
+        MainActivity activity = Robolectric.setupActivity(MainActivity.class);
+
+
+        // make sure the shared preferences has a value
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+        SharedPreferences.Editor editor = sharedPref.edit();
+
+        editor.putString(activity.getString(R.string.pref_passwords), "password1");
+        editor.apply();
+
+        String password = Util.getKnownPassword(activity);
+
+        Assert.assertEquals("password1", password);
+    }
+
+
+    @Test
+    public void clearKnownUser()
+    {
+        MainActivity activity = Robolectric.setupActivity(MainActivity.class);
+
+
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+
+        SharedPreferences.Editor editor = sharedPref.edit();
+
+        // make sure that the user is set
+        editor.putString(activity.getString(R.string.pref_username), "userName2");
+        editor.putString(activity.getString(R.string.pref_passwords), "password2");
+        editor.apply();
+
+        // clear the known user
+        Util.clearKnownUser(activity);
+
+        // check the values that are stored
+        String userName = sharedPref.getString(activity.getString(R.string.pref_username), null);
+        String password = sharedPref.getString(activity.getString(R.string.pref_passwords), null);
+
+        Assert.assertNull(userName);
+        Assert.assertNull(password);
     }
 }

--- a/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
+++ b/app/src/test/java/ca/marshallasch/veil/utilities/UtilTest.java
@@ -6,21 +6,17 @@ import android.preference.PreferenceManager;
 import com.google.protobuf.Timestamp;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-
-import java.util.Date;
-
-import ca.marshallasch.veil.MainActivity;
-import ca.marshallasch.veil.R;
-import ca.marshallasch.veil.proto.DhtProto;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import ca.marshallasch.veil.MainActivity;
+import ca.marshallasch.veil.R;
 import ca.marshallasch.veil.proto.DhtProto;
 
 /**
@@ -28,7 +24,7 @@ import ca.marshallasch.veil.proto.DhtProto;
  * @version 1.0
  * @since 2018-06-13
  */
-@RunWith(RobolectricTestRunner.class)
+//@RunWith(RobolectricTestRunner.class)
 public class UtilTest
 {
     DhtProto.User author = DhtProto.User.newBuilder()
@@ -109,6 +105,7 @@ public class UtilTest
 
 
     @Test
+    @Ignore
     public void rememberUserName()
     {
         MainActivity activity = Robolectric.setupActivity(MainActivity.class);
@@ -126,6 +123,7 @@ public class UtilTest
     }
 
     @Test
+    @Ignore
     public void getKnownUsername()
     {
         MainActivity activity = Robolectric.setupActivity(MainActivity.class);
@@ -145,6 +143,7 @@ public class UtilTest
 
 
     @Test
+    @Ignore
     public void getKnownPassword()
     {
         MainActivity activity = Robolectric.setupActivity(MainActivity.class);
@@ -164,6 +163,7 @@ public class UtilTest
 
 
     @Test
+    @Ignore
     public void clearKnownUser()
     {
         MainActivity activity = Robolectric.setupActivity(MainActivity.class);


### PR DESCRIPTION
Added in tests for rest of util functions. As well as added in null data support for generateHash()

Notes:
The following tests were given an ignore tag since `RobolectricTestRunner.class` doesn't support API 28 yet
- getKnownUsername()
- rememberUserName()
- getKnownPassword()
- clearKnownUser()

this closes #83 