### PR TITLE
117 DB migration 8 issue

### DIFF
--- a/app/src/main/java/ca/marshallasch/veil/database/Migrations.java
+++ b/app/src/main/java/ca/marshallasch/veil/database/Migrations.java
@@ -151,9 +151,9 @@ final class Migrations
 
         String[] projection = {
                 KnownPostsContract.KnownPostsEntry.COLUMN_POST_HASH,
-                KnownPostsContract.KnownPostsEntry.COLUMN_COMMENT_HASH
+                KnownPostsContract.KnownPostsEntry.COLUMN_COMMENT_HASH,
+                KnownPostsContract.KnownPostsEntry.COLUMN_TIME_INSERTED
         };
-
 
         Cursor cursor = db.query(
                 KnownPostsContract.KnownPostsEntry.TABLE_NAME,   // The table to query


### PR DESCRIPTION
closes #117. Fixed the migration issue, when migrating to database version 8 from earlier versions one of the columns of values was forgotten.